### PR TITLE
FeatureCorrelationDetection.scala modified

### DIFF
--- a/src/main/scala/com/databricks/labs/automl/sanitize/FeatureCorrelationDetection.scala
+++ b/src/main/scala/com/databricks/labs/automl/sanitize/FeatureCorrelationDetection.scala
@@ -63,11 +63,11 @@ class FeatureCorrelationDetection(data: DataFrame, fieldListing: Array[String]) 
    //because for every pair of feature a and b, in correlationInteraction (a,b) as well as (b,a) was getting added
     fieldListingPar.foreach(cfeature =>
     {
-      var currIndex = fieldListingPar.indexOf(cfeature)
-      while (currIndex +1 < fieldListingPar.length)
+      var currIndex = fieldListingPar.indexOf(cfeature) //get current index
+      while (currIndex +1 < fieldListingPar.length)    //for every index iterate over next indices only, so that for every (a,b) there won't be (b,a)
       {
         val nextIndex = currIndex + 1
-        val nfeature = fieldsToCheck(nextIndex)
+        val nfeature = fieldListing(nextIndex)      
         val corrStats: Double = try {
           dataFrame.groupBy().agg(corr(cfeature, nfeature).as("pearson")).first().getDouble(0)
         }
@@ -75,7 +75,7 @@ class FeatureCorrelationDetection(data: DataFrame, fieldListing: Array[String]) 
           case e: java.lang.NullPointerException =>
             val errorMsg = s"Correlation Calculation for $cfeature : $nfeature failed.  Recording Inf for correlation."
 
-             logger.log(Level.INFO, errorMsg + s"\n ${e.printStackTrace()}")
+            logger.log(Level.INFO, errorMsg + s"\n ${e.printStackTrace()}")
             Double.PositiveInfinity
         }
         currIndex+=1

--- a/src/main/scala/com/databricks/labs/automl/sanitize/FeatureCorrelationDetection.scala
+++ b/src/main/scala/com/databricks/labs/automl/sanitize/FeatureCorrelationDetection.scala
@@ -75,7 +75,7 @@ class FeatureCorrelationDetection(data: DataFrame, fieldListing: Array[String]) 
           case e: java.lang.NullPointerException =>
             val errorMsg = s"Correlation Calculation for $cfeature : $nfeature failed.  Recording Inf for correlation."
 
-            log.error(errorMsg + s"\n ${e.printStackTrace()}")
+             logger.log(Level.INFO, errorMsg + s"\n ${e.printStackTrace()}")
             Double.PositiveInfinity
         }
         currIndex+=1


### PR DESCRIPTION
In the previous code for feature correlation filtering what I observed is that if a and b have more correlation than given threshold values both a and b features will be removed. But ideally either a or b should be removed. This is because of foreach loop on fieldListingPar. It adds both (a,b, corr(a,b)) and (b,a,corr(b,a)) in correlationInteractions. I've modified that code so that it will only remove one of the features. Either a or b.

Try running the previous code on below modified iris dataset. Either count1 or count2 column should be removed because of a higher positive correlation. But both are getting removed.

sepalLength | c1 | sepalWdth | count1 | petalLength | c2 | petalWidth | count2 | gender | class
5.1 | 1 | 3.5 | 1 | 1.4 | 1 | 0.2 | 1 | m | Iris-setosa
4.9 | 1 | 3 | 2 | 1.4 | 1 | 0.2 | 2 | f | Iris-setosa
4.7 | 1 | 3.2 | 3 | 1.3 | 1 | 0.2 | 3 | m | Iris-setosa
4.6 | 1 | 3.1 | 4 | 1.5 | 1 | 0.2 | 4 | f | Iris-setosa
5 | 1 | 3.6 | 5 | 1.4 | 1 | 0.2 | 5 | m | Iris-setosa
5.4 | 1 | 3.9 | 6 | 1.7 | 1 | 0.4 | 6 | f | Iris-setosa
4.6 | 1 | 3.4 | 7 | 1.4 | 1 | 0.3 | 7 | m | Iris-setosa
5 | 1 | 3.4 | 8 | 1.5 | 1 | 0.2 | 8 | f | Iris-setosa
4.4 | 1 | 2.9 | 9 | 1.4 | 1 | 0.2 | 9 | m | Iris-setosa
4.9 | 1 | 3.1 | 10 | 1.5 | 1 | 0.1 | 10 | f | Iris-setosa
5.4 | 1 | 3.7 | 11 | 1.5 | 1 | 0.2 | 11 | m | Iris-setosa
4.8 | 1 | 3.4 | 12 | 1.6 | 1 | 0.2 | 12 | f | Iris-setosa
4.8 | 1 | 3 | 13 | 1.4 | 1 | 0.1 | 13 | m | Iris-setosa
4.3 | 1 | 3 | 14 | 1.1 | 1 | 0.1 | 14 | f | Iris-setosa
5.8 | 1 | 4 | 15 | 1.2 | 1 | 0.2 | 15 | m | Iris-setosa
5.7 | 1 | 4.4 | 16 | 1.5 | 1 | 0.4 | 16 | f | Iris-setosa
5.4 | 1 | 3.9 | 17 | 1.3 | 1 | 0.4 | 17 | m | Iris-setosa
5.1 | 1 | 3.5 | 18 | 1.4 | 1 | 0.3 | 18 | f | Iris-setosa
5.7 | 1 | 3.8 | 19 | 1.7 | 1 | 0.3 | 19 | m | Iris-setosa
5.1 | 1 | 3.8 | 20 | 1.5 | 1 | 0.3 | 20 | f | Iris-setosa
5.4 | 1 | 3.4 | 21 | 1.7 | 1 | 0.2 | 21 | m | Iris-setosa
5.1 | 1 | 3.7 | 22 | 1.5 | 1 | 0.4 | 22 | f | Iris-setosa
4.6 | 1 | 3.6 | 23 | 1 | 1 | 0.2 | 23 | m | Iris-setosa
5.1 | 1 | 3.3 | 24 | 1.7 | 1 | 0.5 | 24 | f | Iris-setosa
4.8 | 1 | 3.4 | 25 | 1.9 | 1 | 0.2 | 25 | m | Iris-setosa
5 | 1 | 3 | 26 | 1.6 | 1 | 0.2 | 26 | f | Iris-setosa
5 | 1 | 3.4 | 27 | 1.6 | 1 | 0.4 | 27 | m | Iris-setosa
5.2 | 1 | 3.5 | 28 | 1.5 | 1 | 0.2 | 28 | f | Iris-setosa
5.2 | 1 | 3.4 | 29 | 1.4 | 1 | 0.2 | 29 | m | Iris-setosa
4.7 | 1 | 3.2 | 30 | 1.6 | 1 | 0.2 | 30 | f | Iris-setosa
4.8 | 1 | 3.1 | 31 | 1.6 | 1 | 0.2 | 31 | m | Iris-setosa
5.4 | 1 | 3.4 | 32 | 1.5 | 1 | 0.4 | 32 | f | Iris-setosa
5.2 | 1 | 4.1 | 33 | 1.5 | 1 | 0.1 | 33 | m | Iris-setosa
5.5 | 1 | 4.2 | 34 | 1.4 | 1 | 0.2 | 34 | f | Iris-setosa
4.9 | 1 | 3.1 | 35 | 1.5 | 1 | 0.1 | 35 | m | Iris-setosa
5 | 1 | 3.2 | 36 | 1.2 | 1 | 0.2 | 36 | f | Iris-setosa
5.5 | 1 | 3.5 | 37 | 1.3 | 1 | 0.2 | 37 | m | Iris-setosa
4.9 | 1 | 3.1 | 38 | 1.5 | 1 | 0.1 | 38 | f | Iris-setosa
4.4 | 1 | 3 | 39 | 1.3 | 1 | 0.2 | 39 | m | Iris-setosa
5.1 | 1 | 3.4 | 40 | 1.5 | 1 | 0.2 | 40 | f | Iris-setosa
5 | 1 | 3.5 | 41 | 1.3 | 1 | 0.3 | 41 | m | Iris-setosa
4.5 | 1 | 2.3 | 42 | 1.3 | 1 | 0.3 | 42 | f | Iris-setosa
4.4 | 1 | 3.2 | 43 | 1.3 | 1 | 0.2 | 43 | m | Iris-setosa
5 | 1 | 3.5 | 44 | 1.6 | 1 | 0.6 | 44 | f | Iris-setosa
5.1 | 1 | 3.8 | 45 | 1.9 | 1 | 0.4 | 45 | m | Iris-setosa
4.8 | 1 | 3 | 46 | 1.4 | 1 | 0.3 | 46 | f | Iris-setosa
5.1 | 1 | 3.8 | 47 | 1.6 | 1 | 0.2 | 47 | m | Iris-setosa
4.6 | 1 | 3.2 | 48 | 1.4 | 1 | 0.2 | 48 | f | Iris-setosa
5.3 | 1 | 3.7 | 49 | 1.5 | 1 | 0.2 | 49 | m | Iris-setosa
5 | 1 | 3.3 | 50 | 1.4 | 1 | 0.2 | 50 | f | Iris-setosa
7 | 1 | 3.2 | 51 | 4.7 | 1 | 1.4 | 51 | m | Iris-versicolor
6.4 | 1 | 3.2 | 52 | 4.5 | 1 | 1.5 | 52 | f | Iris-versicolor
6.9 | 1 | 3.1 | 53 | 4.9 | 1 | 1.5 | 53 | m | Iris-versicolor
5.5 | 1 | 2.3 | 54 | 4 | 1 | 1.3 | 54 | f | Iris-versicolor
6.5 | 1 | 2.8 | 55 | 4.6 | 1 | 1.5 | 55 | m | Iris-versicolor
5.7 | 1 | 2.8 | 56 | 4.5 | 1 | 1.3 | 56 | f | Iris-versicolor
6.3 | 1 | 3.3 | 57 | 4.7 | 1 | 1.6 | 57 | m | Iris-versicolor
4.9 | 1 | 2.4 | 58 | 3.3 | 1 | 1 | 58 | f | Iris-versicolor
6.6 | 1 | 2.9 | 59 | 4.6 | 1 | 1.3 | 59 | m | Iris-versicolor
5.2 | 1 | 2.7 | 60 | 3.9 | 1 | 1.4 | 60 | f | Iris-versicolor
5 | 1 | 2 | 61 | 3.5 | 1 | 1 | 61 | m | Iris-versicolor
5.9 | 1 | 3 | 62 | 4.2 | 1 | 1.5 | 62 | f | Iris-versicolor
6 | 1 | 2.2 | 63 | 4 | 1 | 1 | 63 | m | Iris-versicolor
6.1 | 1 | 2.9 | 64 | 4.7 | 1 | 1.4 | 64 | f | Iris-versicolor
5.6 | 1 | 2.9 | 65 | 3.6 | 1 | 1.3 | 65 | m | Iris-versicolor
6.7 | 1 | 3.1 | 66 | 4.4 | 1 | 1.4 | 66 | f | Iris-versicolor
5.6 | 1 | 3 | 67 | 4.5 | 1 | 1.5 | 67 | m | Iris-versicolor
5.8 | 1 | 2.7 | 68 | 4.1 | 1 | 1 | 68 | f | Iris-versicolor
6.2 | 1 | 2.2 | 69 | 4.5 | 1 | 1.5 | 69 | m | Iris-versicolor
5.6 | 1 | 2.5 | 70 | 3.9 | 1 | 1.1 | 70 | f | Iris-versicolor
5.9 | 1 | 3.2 | 71 | 4.8 | 1 | 1.8 | 71 | m | Iris-versicolor
6.1 | 1 | 2.8 | 72 | 4 | 1 | 1.3 | 72 | f | Iris-versicolor
6.3 | 1 | 2.5 | 73 | 4.9 | 1 | 1.5 | 73 | m | Iris-versicolor
6.1 | 1 | 2.8 | 74 | 4.7 | 1 | 1.2 | 74 | f | Iris-versicolor
6.4 | 1 | 2.9 | 75 | 4.3 | 1 | 1.3 | 75 | m | Iris-versicolor
6.6 | 1 | 3 | 76 | 4.4 | 1 | 1.4 | 76 | f | Iris-versicolor
6.8 | 1 | 2.8 | 77 | 4.8 | 1 | 1.4 | 77 | m | Iris-versicolor
6.7 | 1 | 3 | 78 | 5 | 1 | 1.7 | 78 | f | Iris-versicolor
6 | 1 | 2.9 | 79 | 4.5 | 1 | 1.5 | 79 | m | Iris-versicolor
5.7 | 1 | 2.6 | 80 | 3.5 | 1 | 1 | 80 | f | Iris-versicolor
5.5 | 1 | 2.4 | 81 | 3.8 | 1 | 1.1 | 81 | m | Iris-versicolor
5.5 | 1 | 2.4 | 82 | 3.7 | 1 | 1 | 82 | f | Iris-versicolor
5.8 | 1 | 2.7 | 83 | 3.9 | 1 | 1.2 | 83 | m | Iris-versicolor
6 | 1 | 2.7 | 84 | 5.1 | 1 | 1.6 | 84 | f | Iris-versicolor
5.4 | 1 | 3 | 85 | 4.5 | 1 | 1.5 | 85 | m | Iris-versicolor
6 | 1 | 3.4 | 86 | 4.5 | 1 | 1.6 | 86 | f | Iris-versicolor
6.7 | 1 | 3.1 | 87 | 4.7 | 1 | 1.5 | 87 | m | Iris-versicolor
6.3 | 1 | 2.3 | 88 | 4.4 | 1 | 1.3 | 88 | f | Iris-versicolor
5.6 | 1 | 3 | 89 | 4.1 | 1 | 1.3 | 89 | m | Iris-versicolor
5.5 | 1 | 2.5 | 90 | 4 | 1 | 1.3 | 90 | f | Iris-versicolor
5.5 | 1 | 2.6 | 91 | 4.4 | 1 | 1.2 | 91 | m | Iris-versicolor
6.1 | 1 | 3 | 92 | 4.6 | 1 | 1.4 | 92 | f | Iris-versicolor
5.8 | 1 | 2.6 | 93 | 4 | 1 | 1.2 | 93 | m | Iris-versicolor
5 | 1 | 2.3 | 94 | 3.3 | 1 | 1 | 94 | f | Iris-versicolor
5.6 | 1 | 2.7 | 95 | 4.2 | 1 | 1.3 | 95 | m | Iris-versicolor
5.7 | 1 | 3 | 96 | 4.2 | 1 | 1.2 | 96 | f | Iris-versicolor
5.7 | 1 | 2.9 | 97 | 4.2 | 1 | 1.3 | 97 | m | Iris-versicolor
6.2 | 1 | 2.9 | 98 | 4.3 | 1 | 1.3 | 98 | f | Iris-versicolor
5.1 | 1 | 2.5 | 99 | 3 | 1 | 1.1 | 99 | m | Iris-versicolor
5.7 | 1 | 2.8 | 100 | 4.1 | 1 | 1.3 | 100 | f | Iris-versicolor
6.3 | 1 | 3.3 | 101 | 6 | 1 | 2.5 | 101 | m | Iris-virginica
5.8 | 1 | 2.7 | 102 | 5.1 | 1 | 1.9 | 102 | f | Iris-virginica
7.1 | 1 | 3 | 103 | 5.9 | 1 | 2.1 | 103 | m | Iris-virginica
6.3 | 1 | 2.9 | 104 | 5.6 | 1 | 1.8 | 104 | f | Iris-virginica
6.5 | 1 | 3 | 105 | 5.8 | 1 | 2.2 | 105 | m | Iris-virginica
7.6 | 1 | 3 | 106 | 6.6 | 1 | 2.1 | 106 | f | Iris-virginica
4.9 | 1 | 2.5 | 107 | 4.5 | 1 | 1.7 | 107 | m | Iris-virginica
7.3 | 1 | 2.9 | 108 | 6.3 | 1 | 1.8 | 108 | f | Iris-virginica
6.7 | 1 | 2.5 | 109 | 5.8 | 1 | 1.8 | 109 | m | Iris-virginica
7.2 | 1 | 3.6 | 110 | 6.1 | 1 | 2.5 | 110 | f | Iris-virginica
6.5 | 1 | 3.2 | 111 | 5.1 | 1 | 2 | 111 | m | Iris-virginica
6.4 | 1 | 2.7 | 112 | 5.3 | 1 | 1.9 | 112 | f | Iris-virginica
6.8 | 1 | 3 | 113 | 5.5 | 1 | 2.1 | 113 | m | Iris-virginica
5.7 | 1 | 2.5 | 114 | 5 | 1 | 2 | 114 | f | Iris-virginica
5.8 | 1 | 2.8 | 115 | 5.1 | 1 | 2.4 | 115 | m | Iris-virginica
6.4 | 1 | 3.2 | 116 | 5.3 | 1 | 2.3 | 116 | f | Iris-virginica
6.5 | 1 | 3 | 117 | 5.5 | 1 | 1.8 | 117 | m | Iris-virginica
7.7 | 1 | 3.8 | 118 | 6.7 | 1 | 2.2 | 118 | f | Iris-virginica
7.7 | 1 | 2.6 | 119 | 6.9 | 1 | 2.3 | 119 | m | Iris-virginica
6 | 1 | 2.2 | 120 | 5 | 1 | 1.5 | 120 | f | Iris-virginica
6.9 | 1 | 3.2 | 121 | 5.7 | 1 | 2.3 | 121 | m | Iris-virginica
5.6 | 1 | 2.8 | 122 | 4.9 | 1 | 2 | 122 | f | Iris-virginica
7.7 | 1 | 2.8 | 123 | 6.7 | 1 | 2 | 123 | m | Iris-virginica
6.3 | 1 | 2.7 | 124 | 4.9 | 1 | 1.8 | 124 | f | Iris-virginica
6.7 | 1 | 3.3 | 125 | 5.7 | 1 | 2.1 | 125 | m | Iris-virginica
7.2 | 1 | 3.2 | 126 | 6 | 1 | 1.8 | 126 | f | Iris-virginica
6.2 | 1 | 2.8 | 127 | 4.8 | 1 | 1.8 | 127 | m | Iris-virginica
6.1 | 1 | 3 | 128 | 4.9 | 1 | 1.8 | 128 | f | Iris-virginica
6.4 | 1 | 2.8 | 129 | 5.6 | 1 | 2.1 | 129 | m | Iris-virginica
7.2 | 1 | 3 | 130 | 5.8 | 1 | 1.6 | 130 | f | Iris-virginica
7.4 | 1 | 2.8 | 131 | 6.1 | 1 | 1.9 | 131 | m | Iris-virginica
7.9 | 1 | 3.8 | 132 | 6.4 | 1 | 2 | 132 | f | Iris-virginica
6.4 | 1 | 2.8 | 133 | 5.6 | 1 | 2.2 | 133 | m | Iris-virginica
6.3 | 1 | 2.8 | 134 | 5.1 | 1 | 1.5 | 134 | f | Iris-virginica
6.1 | 1 | 2.6 | 135 | 5.6 | 1 | 1.4 | 135 | m | Iris-virginica
7.7 | 1 | 3 | 136 | 6.1 | 1 | 2.3 | 136 | f | Iris-virginica
6.3 | 1 | 3.4 | 137 | 5.6 | 1 | 2.4 | 137 | m | Iris-virginica
6.4 | 1 | 3.1 | 138 | 5.5 | 1 | 1.8 | 138 | f | Iris-virginica
6 | 1 | 3 | 139 | 4.8 | 1 | 1.8 | 139 | m | Iris-virginica
6.9 | 1 | 3.1 | 140 | 5.4 | 1 | 2.1 | 140 | f | Iris-virginica
6.7 | 1 | 3.1 | 141 | 5.6 | 1 | 2.4 | 141 | m | Iris-virginica
6.9 | 1 | 3.1 | 142 | 5.1 | 1 | 2.3 | 142 | f | Iris-virginica
5.8 | 1 | 2.7 | 143 | 5.1 | 1 | 1.9 | 143 | m | Iris-virginica
6.8 | 1 | 3.2 | 144 | 5.9 | 1 | 2.3 | 144 | f | Iris-virginica
6.7 | 1 | 3.3 | 145 | 5.7 | 1 | 2.5 | 145 | m | Iris-virginica
6.7 | 1 | 3 | 146 | 5.2 | 1 | 2.3 | 146 | f | Iris-virginica
6.3 | 1 | 2.5 | 147 | 5 | 1 | 1.9 | 147 | m | Iris-virginica
6.5 | 1 | 3 | 148 | 5.2 | 1 | 2 | 148 | f | Iris-virginica
6.2 | 1 | 3.4 | 149 | 5.4 | 1 | 2.3 | 149 | m | Iris-virginica
5.9 | 1 | 3 | 150 | 5.1 | 1 | 1.8 | 150 | f | Iris-virginica

