### PR TITLE
adding missing dependency in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,6 +103,11 @@
             <artifactId>mleap-spark_2.11</artifactId>
             <version>0.14.0</version>
         </dependency>
+	<dependency>
+            <groupId>org.vegas-viz</groupId>
+            <artifactId>vegas_2.11</artifactId>
+            <version>0.3.11</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>


### PR DESCRIPTION
1. Adding  'vegas' dependency in pom.xml.This dependency is present in build.sbt.
@bali0019 @BenWilson2 @GeekSheikh 